### PR TITLE
Add VersionedAVLStorage::flush() for durable commits on demand

### DIFF
--- a/src/versioned_avl_storage.rs
+++ b/src/versioned_avl_storage.rs
@@ -53,4 +53,17 @@ pub trait VersionedAVLStorage {
     /// @return versions store keeps
     ///
     fn rollback_versions<'a>(&'a self) -> Box<dyn Iterator<Item = ADDigest> + 'a>;
+
+    ////
+    /// Force a durable commit of outstanding writes. Implementations that
+    /// use deferred/non-durable writes (e.g. `Durability::None` in redb)
+    /// should fsync the backing store here. Default is a no-op for
+    /// in-memory or always-durable storages.
+    ///
+    /// Callers should invoke this periodically during long-running write
+    /// sequences and on graceful shutdown to bound crash data loss.
+    ///
+    fn flush(&self) -> Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
Adds a default-no-op flush() method to VersionedAVLStorage so callers can force a durable commit. Storages with deferred writes (e.g. redb Durability::None) lose state on graceful shutdown without an explicit fsync — reopen sees no valid commit.

Default no-op keeps existing impls unaffected; deferred-write impls override.
