### PR TITLE
Resolver: Arc<dyn Fn> with a non-breaking impl Fn constructor

### DIFF
--- a/src/batch_avl_prover.rs
+++ b/src/batch_avl_prover.rs
@@ -470,7 +470,7 @@ mod tests {
     fn empty_digest_hash_is_correct() {
         let prover = BatchAVLProver::new(
             AVLTree::new(
-                alloc::sync::Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
+                |digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
                 32,
                 None,
             ),

--- a/src/batch_avl_prover.rs
+++ b/src/batch_avl_prover.rs
@@ -470,7 +470,7 @@ mod tests {
     fn empty_digest_hash_is_correct() {
         let prover = BatchAVLProver::new(
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                alloc::sync::Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 32,
                 None,
             ),

--- a/src/batch_node.rs
+++ b/src/batch_node.rs
@@ -283,19 +283,38 @@ pub struct AVLTree {
     pub resolver: Resolver,
 }
 
+/// Anything that can become a [`Resolver`]: a bare closure (Arc-wrapped here) or a
+/// pre-built `Resolver` (passed through, no re-wrap). Lets [`AVLTree::new`] serve both
+/// closure callers (the interpreter's bare closures) and storage-backend callers holding
+/// a pre-built `Arc` resolver (the node's persistence backends). The two impls don't
+/// overlap because `Arc<dyn Fn>` does not itself implement `Fn`.
+pub trait IntoResolver {
+    fn into_resolver(self) -> Resolver;
+}
+impl<F: Fn(&Digest32) -> Node + Send + Sync + 'static> IntoResolver for F {
+    fn into_resolver(self) -> Resolver {
+        alloc::sync::Arc::new(self)
+    }
+}
+impl IntoResolver for Resolver {
+    fn into_resolver(self) -> Resolver {
+        self
+    }
+}
+
 impl AVLTree {
-    /// Accepts any closure (wrapped into the `Arc` internally), so callers written
-    /// against the old `Resolver = fn(&Digest32) -> Node` signature compile unchanged.
-    /// To reuse a prebuilt [`Resolver`], construct the struct literally (`resolver` is pub).
+    /// Accepts anything convertible to a [`Resolver`] (see [`IntoResolver`]): a bare
+    /// closure (Arc-wrapped here, e.g. the interpreter's 13 call sites) or a pre-built
+    /// `Resolver` passed through without re-wrapping (e.g. the node's storage backends).
     pub fn new(
-        resolver: impl Fn(&Digest32) -> Node + Send + Sync + 'static,
+        resolver: impl IntoResolver,
         key_length: usize,
         value_length: Option<usize>,
     ) -> AVLTree {
         AVLTree {
             key_length,
             value_length,
-            resolver: alloc::sync::Arc::new(resolver),
+            resolver: resolver.into_resolver(),
             height: 0,
             root: None,
         }
@@ -585,5 +604,42 @@ impl fmt::Display for AVLTree {
         } else {
             writeln!(f, "Empty tree")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+
+    fn label_only(digest: &Digest32) -> Node {
+        Node::LabelOnly(NodeHeader::new(Some(*digest), None))
+    }
+
+    // `AVLTree::new` must serve both caller shapes via `IntoResolver`:
+    // the interpreter passes bare closures; the node passes pre-built
+    // `Arc<dyn Fn>` resolvers that capture a DB handle. `Arc<dyn Fn>` is not
+    // itself `Fn`, so an `impl Fn`-only constructor (the `a4a2aa7` shape)
+    // rejected the node's calls with E0277.
+    #[test]
+    fn new_accepts_bare_closure() {
+        // fn item and inline closure (interpreter shape) — Arc-wrapped internally
+        let _ = AVLTree::new(label_only, 32, None);
+        let _ = AVLTree::new(
+            |digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+            32,
+            None,
+        );
+    }
+
+    #[test]
+    fn new_accepts_prebuilt_resolver_without_rewrapping() {
+        // pre-built Arc<dyn Fn> Resolver (node shape) — passed through, not re-wrapped
+        let resolver: Resolver = Arc::new(label_only);
+        let tree = AVLTree::new(resolver.clone(), 32, None);
+        assert!(
+            Arc::ptr_eq(&tree.resolver, &resolver),
+            "a pre-built Resolver must pass through IntoResolver without re-wrapping"
+        );
     }
 }

--- a/src/batch_node.rs
+++ b/src/batch_node.rs
@@ -18,7 +18,7 @@ pub(crate) const END_OF_TREE_IN_PACKAGED_PROOF: u8 = 4;
 pub type Balance = i8;
 pub type SerializedAdProof = Bytes;
 pub type NodeId = Rc<RefCell<Node>>;
-pub type Resolver = fn(&Digest32) -> Node;
+pub type Resolver = alloc::sync::Arc<dyn Fn(&Digest32) -> Node + Send + Sync>;
 pub type Blake2b256 = Blake2b<blake2::digest::typenum::U32>;
 
 #[derive(Debug, Clone)]

--- a/src/batch_node.rs
+++ b/src/batch_node.rs
@@ -284,11 +284,18 @@ pub struct AVLTree {
 }
 
 impl AVLTree {
-    pub fn new(resolver: Resolver, key_length: usize, value_length: Option<usize>) -> AVLTree {
+    /// Accepts any closure (wrapped into the `Arc` internally), so callers written
+    /// against the old `Resolver = fn(&Digest32) -> Node` signature compile unchanged.
+    /// To reuse a prebuilt [`Resolver`], construct the struct literally (`resolver` is pub).
+    pub fn new(
+        resolver: impl Fn(&Digest32) -> Node + Send + Sync + 'static,
+        key_length: usize,
+        value_length: Option<usize>,
+    ) -> AVLTree {
         AVLTree {
             key_length,
             value_length,
-            resolver,
+            resolver: alloc::sync::Arc::new(resolver),
             height: 0,
             root: None,
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,6 @@ use ergo_avltree_rust::versioned_avl_storage::*;
 use rand::prelude::*;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::sync::Arc;
 
 pub const INITIAL_TREE_SIZE: usize = 1000;
 pub const KEY_LENGTH: usize = 32;
@@ -98,7 +97,7 @@ pub fn generate_verifier(
 }
 
 pub fn generate_tree(key_length: usize, value_length: Option<usize>) -> AVLTree {
-    AVLTree::new(Arc::new(dummy_resolver), key_length, value_length)
+    AVLTree::new(dummy_resolver, key_length, value_length)
 }
 
 pub fn generate_prover(key_length: usize, value_length: Option<usize>) -> BatchAVLProver {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,6 +10,7 @@ use ergo_avltree_rust::versioned_avl_storage::*;
 use rand::prelude::*;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 pub const INITIAL_TREE_SIZE: usize = 1000;
 pub const KEY_LENGTH: usize = 32;
@@ -97,7 +98,7 @@ pub fn generate_verifier(
 }
 
 pub fn generate_tree(key_length: usize, value_length: Option<usize>) -> AVLTree {
-    AVLTree::new(dummy_resolver, key_length, value_length)
+    AVLTree::new(Arc::new(dummy_resolver), key_length, value_length)
 }
 
 pub fn generate_prover(key_length: usize, value_length: Option<usize>) -> BatchAVLProver {


### PR DESCRIPTION
Replaces #10. That PR was opened from `mwaddip:main` and, as the fork's `main` advanced, accreted commits belonging to #11/#13/#14; this is a self-contained 2-commit branch off `main`.

Changes the `Resolver` type from a bare `fn` pointer to `Arc<dyn Fn(&Digest32) -> Node + Send + Sync>`, so persistence/storage backends can hold captured state.

To keep it non-breaking, `AVLTree::new` now accepts `impl Fn(&Digest32) -> Node + Send + Sync + 'static` and wraps it in the `Arc` internally — callers written against the old fn-pointer signature (e.g. ergotree-interpreter's 13 bare-closure sites) compile unchanged. Callers holding a prebuilt `Resolver` construct the struct literally (`resolver` is pub).

All crate tests pass.