### PR TITLE
Resolver: Arc<dyn Fn> with new(impl Fn) + with_resolver constructors

### DIFF
--- a/src/batch_avl_prover.rs
+++ b/src/batch_avl_prover.rs
@@ -470,7 +470,7 @@ mod tests {
     fn empty_digest_hash_is_correct() {
         let prover = BatchAVLProver::new(
             AVLTree::new(
-                alloc::sync::Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
+                |digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
                 32,
                 None,
             ),

--- a/src/batch_avl_prover.rs
+++ b/src/batch_avl_prover.rs
@@ -470,7 +470,7 @@ mod tests {
     fn empty_digest_hash_is_correct() {
         let prover = BatchAVLProver::new(
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                alloc::sync::Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 32,
                 None,
             ),

--- a/src/batch_node.rs
+++ b/src/batch_node.rs
@@ -284,9 +284,10 @@ pub struct AVLTree {
 }
 
 impl AVLTree {
-    /// Accepts any closure (wrapped into the `Arc` internally), so callers written
-    /// against the old `Resolver = fn(&Digest32) -> Node` signature compile unchanged.
-    /// To reuse a prebuilt [`Resolver`], construct the struct literally (`resolver` is pub).
+    /// Accepts any closure (wrapped into the `Arc` internally). The `impl Fn` bound lets
+    /// callers pass a bare, unannotated closure (e.g. `|digest| …`) and have its parameter
+    /// type inferred — the shape every closure caller (the interpreter) relies on.
+    /// To pass a pre-built [`Resolver`] (`Arc<dyn Fn>`), use [`AVLTree::with_resolver`].
     pub fn new(
         resolver: impl Fn(&Digest32) -> Node + Send + Sync + 'static,
         key_length: usize,
@@ -296,6 +297,25 @@ impl AVLTree {
             key_length,
             value_length,
             resolver: alloc::sync::Arc::new(resolver),
+            height: 0,
+            root: None,
+        }
+    }
+
+    /// Construct from a pre-built [`Resolver`] (an `Arc<dyn Fn(&Digest32) -> Node + …>`),
+    /// e.g. a persistence backend's node loader that captures a DB handle. Passed through
+    /// without re-wrapping. Closure callers use [`AVLTree::new`] instead — a single
+    /// `impl Fn` constructor cannot also accept an `Arc<dyn Fn>` (it isn't `Fn`), and an
+    /// `impl IntoResolver`-style bound would break unannotated closures (E0282).
+    pub fn with_resolver(
+        resolver: Resolver,
+        key_length: usize,
+        value_length: Option<usize>,
+    ) -> AVLTree {
+        AVLTree {
+            key_length,
+            value_length,
+            resolver,
             height: 0,
             root: None,
         }
@@ -585,5 +605,38 @@ impl fmt::Display for AVLTree {
         } else {
             writeln!(f, "Empty tree")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+
+    // `new` must accept a bare, UNANNOTATED closure with its parameter type inferred —
+    // the exact shape the interpreter uses at its 13 `AVLTree::new` sites. This only
+    // works because the bound is literally `Fn(&Digest32) -> Node`; an `impl IntoResolver`
+    // (non-`Fn`) bound made this fail with E0282, which is why `new` stays `impl Fn`.
+    #[test]
+    fn new_accepts_unannotated_closure() {
+        let _ = AVLTree::new(
+            |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+            32,
+            None,
+        );
+    }
+
+    // `with_resolver` takes a pre-built `Arc<dyn Fn>` Resolver (the node's storage-backend
+    // shape) and stores it WITHOUT re-wrapping — `Arc<dyn Fn>` isn't `Fn`, so it can't go
+    // through `new`'s `impl Fn` bound.
+    #[test]
+    fn with_resolver_stores_prebuilt_arc_without_rewrapping() {
+        let resolver: Resolver =
+            Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None)));
+        let tree = AVLTree::with_resolver(resolver.clone(), 32, None);
+        assert!(
+            Arc::ptr_eq(&tree.resolver, &resolver),
+            "with_resolver must store the pre-built Resolver without re-wrapping"
+        );
     }
 }

--- a/src/batch_node.rs
+++ b/src/batch_node.rs
@@ -18,7 +18,7 @@ pub(crate) const END_OF_TREE_IN_PACKAGED_PROOF: u8 = 4;
 pub type Balance = i8;
 pub type SerializedAdProof = Bytes;
 pub type NodeId = Rc<RefCell<Node>>;
-pub type Resolver = fn(&Digest32) -> Node;
+pub type Resolver = alloc::sync::Arc<dyn Fn(&Digest32) -> Node + Send + Sync>;
 pub type Blake2b256 = Blake2b<blake2::digest::typenum::U32>;
 
 #[derive(Debug, Clone)]

--- a/src/batch_node.rs
+++ b/src/batch_node.rs
@@ -284,11 +284,18 @@ pub struct AVLTree {
 }
 
 impl AVLTree {
-    pub fn new(resolver: Resolver, key_length: usize, value_length: Option<usize>) -> AVLTree {
+    /// Accepts any closure (wrapped into the `Arc` internally), so callers written
+    /// against the old `Resolver = fn(&Digest32) -> Node` signature compile unchanged.
+    /// To reuse a prebuilt [`Resolver`], construct the struct literally (`resolver` is pub).
+    pub fn new(
+        resolver: impl Fn(&Digest32) -> Node + Send + Sync + 'static,
+        key_length: usize,
+        value_length: Option<usize>,
+    ) -> AVLTree {
         AVLTree {
             key_length,
             value_length,
-            resolver,
+            resolver: alloc::sync::Arc::new(resolver),
             height: 0,
             root: None,
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,6 @@ use ergo_avltree_rust::versioned_avl_storage::*;
 use rand::prelude::*;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::sync::Arc;
 
 pub const INITIAL_TREE_SIZE: usize = 1000;
 pub const KEY_LENGTH: usize = 32;
@@ -98,7 +97,7 @@ pub fn generate_verifier(
 }
 
 pub fn generate_tree(key_length: usize, value_length: Option<usize>) -> AVLTree {
-    AVLTree::new(Arc::new(dummy_resolver), key_length, value_length)
+    AVLTree::new(dummy_resolver, key_length, value_length)
 }
 
 pub fn generate_prover(key_length: usize, value_length: Option<usize>) -> BatchAVLProver {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,6 +10,7 @@ use ergo_avltree_rust::versioned_avl_storage::*;
 use rand::prelude::*;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 pub const INITIAL_TREE_SIZE: usize = 1000;
 pub const KEY_LENGTH: usize = 32;
@@ -97,7 +98,7 @@ pub fn generate_verifier(
 }
 
 pub fn generate_tree(key_length: usize, value_length: Option<usize>) -> AVLTree {
-    AVLTree::new(dummy_resolver, key_length, value_length)
+    AVLTree::new(Arc::new(dummy_resolver), key_length, value_length)
 }
 
 pub fn generate_prover(key_length: usize, value_length: Option<usize>) -> BatchAVLProver {


### PR DESCRIPTION
Replaces #15 (closed). Gives upstream the storage-backend resolver capability without breaking the interpreter or the node, via two shape-matched constructors:

- `Resolver = Arc<dyn Fn(&Digest32) -> Node + Send + Sync>` — the persistence need (orig #10).
- `new(resolver: impl Fn(&Digest32) -> Node + …)` — Arc-wraps internally; lets closure callers pass bare UNANNOTATED closures (e.g. the interpreter`'s `|digest| …` sites) with the param type inferred.
- `with_resolver(resolver: Resolver, …)` — takes a pre-built Arc directly (no re-wrap), for storage backends that capture a DB handle.

A single generic constructor cannot serve both: `impl Fn` rejects `Arc<dyn Fn>` (not `Fn`, E0277), and a bound that accepts the Arc breaks unannotated closures (E0282). All crate tests pass.